### PR TITLE
Fix config file on context

### DIFF
--- a/pkg/context.go
+++ b/pkg/context.go
@@ -133,7 +133,7 @@ func NewContext() (*Context, error) {
 	return &Context{
 		Binaries:     binaries,
 		BinPath:      binPath,
-		ConfigPath:   configPath,
+		ConfigPath:   configFilePath,
 		Config:       config,
 		Platform:     runtime.GOOS,
 		Architecture: runtime.GOARCH,


### PR DESCRIPTION
## Problem
`grab update` was unable to write out an updated config file:
```
❯ grab update                                  
adamctl: 0.0.5 is latest
grab: 0.0.44 is latest
starship: 1.17.1 is latest
scope-intercept: 2024.1.27 -> 2024.1.37 (https://github.com/ethankhall/scope/releases/tag/2024.1.37)
delta: 0.16.5 is latest
direnv: 2.33.0 is latest
fzf: 0.45.0 -> 0.46.0 (https://github.com/junegunn/fzf/releases/tag/0.46.0)
lefthook: 1.6.0 -> 1.6.1 (https://github.com/evilmartians/lefthook/releases/tag/v1.6.1)
rg: 14.1.0 is latest
scope: 2024.1.27 -> 2024.1.37 (https://github.com/ethankhall/scope/releases/tag/2024.1.37)
Error: error upgrading: error updating config file: error opening existing config file: open /home/adam/.grab: is a directory
```

## Fix
After fixing the config file path on context:
```
❯ ./grab update                                                         
adamctl: 0.0.5 is latest                                                         
lefthook: 1.6.0 -> 1.6.1 (https://github.com/evilmartians/lefthook/releases/tag/v1.6.1)
rg: 14.1.0 is latest  
starship: 1.17.1 is latest
scope-intercept: 2024.1.27 -> 2024.1.37 (https://github.com/ethankhall/scope/releases/tag/2024.1.37)
delta: 0.16.5 is latest
direnv: 2.33.0 is latest
fzf: 0.45.0 -> 0.46.0 (https://github.com/junegunn/fzf/releases/tag/0.46.0)
grab: 0.0.44 is latest                                                                                                                                            
scope: 2024.1.27 -> 2024.1.37 (https://github.com/ethankhall/scope/releases/tag/2024.1.37)

Updated config file. Now run `grab install`.
```