### PR TITLE
Avoid /tmp & dest different device file move error

### DIFF
--- a/pkg/installer.go
+++ b/pkg/installer.go
@@ -150,7 +150,7 @@ func writeToDisk(binary *Binary, data *[]byte, destPath string) error {
 		return fmt.Errorf("error removing temp file: %w", err)
 	}
 
-	//nolint:gosec,mnd
+	//nolint:gosec,gomnd
 	err = os.WriteFile(tempPath, *data, 0o755)
 	if err != nil {
 		return fmt.Errorf("error writing executable to temp location: %w", err)


### PR DESCRIPTION
## Problem
When `/tmp` and the destination device are on different devices, the `os.Rename` call will fail with:
```
fzf: installing 0.63.0...Error: error installing: error moving temp to destination: rename /tmp/grab-installer-temp1030544718/fzf /home/adam/.local/bin/fzf: invalid cross-device link
```

The low-level `os.Rename` function cannot move files across devices.

## Solution
Write the temporary file to the destination directory instead. The trade-off here is a failure in between the `os.Write` and `os.Rename` may leave a temporary file in the destination directory.