### PR TITLE
Make embedded binary path a template with version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ spec:
       linux,arm64: "archive-{{ .Version }}-linux_arm64.tar.gz"
     embeddedBinaryPath:
       darwin,amd64: "path/to/binary"
-      linux,amd64: "bin/binary"
+      linux,amd64: "{{ .Version }}ed/path/to/binary"
   program:
     versionArgs: [--version]
     versionRegex: \d+\.\d+\.\d+
@@ -112,7 +112,7 @@ spec:
 - `name`: Release name template (Go templated string, with `Version` available)
 - `versionRegex`: Regular expression to extract version numbers from release names
 - `fileName`: Platform-specific asset archive filenames (Go templated string, with `Version` available)
-- `embeddedBinaryPath`: _(Optional)_ Platform-specific path to binary within the archive
+- `embeddedBinaryPath`: _(Optional)_ Platform-specific path to binary within the archive (Go templated string, with `Version` available)
 
 **Program Configuration**
 - `versionArgs`: Command-line arguments to retrieve the program's version
@@ -137,29 +137,29 @@ packages:
 
 ### Advanced Examples
 
-#### Complex Package with Embedded Binary Path
+#### Complex package with version specific embedded binary path
 
 ```yaml
 apiVersion: grab.noizwaves.com/v1alpha1
 kind: Package
 metadata:
-  name: yazi
+  name: crush
 spec:
   gitHubRelease:
-    org: sxyazi
-    repo: yazi
+    org: charmbracelet
+    repo: crush
     name: "v{{ .Version }}"
     versionRegex: \d+\.\d+\.\d+
     fileName:
-      darwin,amd64: "yazi-x86_64-apple-darwin.zip"
-      darwin,arm64: "yazi-aarch64-apple-darwin.zip"
-      linux,amd64: "yazi-x86_64-unknown-linux-gnu.zip"
-      linux,arm64: "yazi-aarch64-unknown-linux-gnu.zip"
+      darwin,amd64: crush_{{ .Version }}_Darwin_x86_64.tar.gz
+      darwin,arm64: crush_{{ .Version }}_Darwin_arm64.tar.gz
+      linux,amd64: crush_{{ .Version }}_Linux_x86_64.tar.gz
+      linux,arm64: crush_{{ .Version }}_Linux_arm64.tar.gz
     embeddedBinaryPath:
-      darwin,amd64: "yazi-x86_64-apple-darwin/yazi"
-      darwin,arm64: "yazi-aarch64-apple-darwin/yazi"
-      linux,amd64: "yazi-x86_64-unknown-linux-gnu/yazi"
-      linux,arm64: "yazi-aarch64-unknown-linux-gnu/yazi"
+      darwin,amd64: crush_{{ .Version }}_Darwin_x86_64/crush
+      darwin,arm64: crush_{{ .Version }}_Darwin_arm64/crush
+      linux,amd64: crush_{{ .Version }}_Linux_x86_64/crush
+      linux,arm64: crush_{{ .Version }}_Linux_arm64/crush
   program:
     versionArgs: [--version]
     versionRegex: \d+\.\d+\.\d+

--- a/pkg/model.go
+++ b/pkg/model.go
@@ -67,7 +67,7 @@ func (b *Binary) GetAssetFileName(platform, arch string) (string, error) {
 		return "", fmt.Errorf("filename missing for platform,arch of %q", key)
 	}
 
-	tmpl, err := template.New("filename:" + b.Name).Parse(fileNameTmplStr)
+	tmpl, err := template.New("filename:" + b.Name + "," + key).Parse(fileNameTmplStr)
 	if err != nil {
 		return "", fmt.Errorf("error parsing asset filename template: %w", err)
 	}
@@ -91,14 +91,28 @@ func (b *Binary) GetEmbeddedBinaryPath(platform, arch string) (string, error) {
 	}
 
 	key := platform + "," + arch
-	embeddedBinaryPath, ok := b.embeddedBinaryPath[key]
+	embeddedBinaryPathTmplStr, ok := b.embeddedBinaryPath[key]
 
 	// A missing key is a hard failure
 	if !ok {
 		return "", fmt.Errorf("missing value for platform=%s,arch=%s", platform, arch)
 	}
 
-	return embeddedBinaryPath, nil
+	tmpl, err := template.New("embeddedBinaryPath:" + b.Name).Parse(embeddedBinaryPathTmplStr)
+	if err != nil {
+		return "", fmt.Errorf("error parsing embedded binary path template: %w", err)
+	}
+
+	vm := newURLViewModel(b)
+
+	var output bytes.Buffer
+
+	err = tmpl.Execute(&output, vm)
+	if err != nil {
+		return "", fmt.Errorf("error rendering embedded binary path template: %w", err)
+	}
+
+	return output.String(), nil
 }
 
 func (b *Binary) GetReleaseName() (string, error) {

--- a/pkg/model_test.go
+++ b/pkg/model_test.go
@@ -138,6 +138,40 @@ func TestGetEmbeddedBinaryPath(t *testing.T) {
 		assert.Equal(t, "", result)
 		assert.ErrorContains(t, err, "missing value for platform=linux,arch=amd64")
 	})
+
+	t.Run("EmbeddedBinaryPathWithVersion", func(t *testing.T) {
+		binary := base
+		binary.embeddedBinaryPath = map[string]string{
+			"linux,arm64": "bin/{{ .Version }}/foo",
+		}
+
+		result, err := binary.GetEmbeddedBinaryPath("linux", "arm64")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "bin/1.2.3/foo", result)
+	})
+
+	t.Run("InvalidEmbeddedBinaryPathTemplate", func(t *testing.T) {
+		binary := base
+		binary.embeddedBinaryPath = map[string]string{
+			"linux,arm64": "bin/{{ .Version",
+		}
+
+		_, err := binary.GetEmbeddedBinaryPath("linux", "arm64")
+
+		assert.ErrorContains(t, err, "error parsing embedded binary path template")
+	})
+
+	t.Run("InvalidEmbeddedBinaryPathVariable", func(t *testing.T) {
+		binary := base
+		binary.embeddedBinaryPath = map[string]string{
+			"linux,arm64": "bin/{{ .DoesNotExist }}/foo",
+		}
+
+		_, err := binary.GetEmbeddedBinaryPath("linux", "arm64")
+
+		assert.ErrorContains(t, err, "error rendering embedded binary path template")
+	})
 }
 
 func TestBinaryShouldReplace(t *testing.T) {


### PR DESCRIPTION
To support [Crush](https://github.com/charmbracelet/crush/releases/tag/v0.2.1), with includes version numbers in the root directory of the archive.