### PR TITLE
Enhance `grab import` to detect embedded binary paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /grab
 /.claude/settings.local.json
+/.serena
 
 # OS specific
 .DS_Store

--- a/pkg/archive.go
+++ b/pkg/archive.go
@@ -154,7 +154,7 @@ func ListZipContents(data io.Reader) ([]string, error) {
 		return nil, fmt.Errorf("error decompressing Zipped data: %w", err)
 	}
 
-	var files []string
+	files := make([]string, 0, len(decompressed.File))
 	for _, entry := range decompressed.File {
 		files = append(files, entry.Name)
 	}
@@ -175,6 +175,7 @@ func ListTarContents(data io.Reader) ([]string, error) {
 	tarReader := tar.NewReader(data)
 
 	var files []string
+
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {

--- a/pkg/archive_test.go
+++ b/pkg/archive_test.go
@@ -1,181 +1,205 @@
 package pkg
 
 import (
-	"os"
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ulikunitz/xz"
 )
 
-func TestUnTgzFileNamedValid(t *testing.T) {
-	for _, testCase := range []struct {
-		Name           string
-		BinaryName     string
-		ExpectedErr    string
-		ExpectedResult string
+func TestListTgzContents(t *testing.T) {
+	// Create test tar.gz content
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	// Add test files
+	files := []struct {
+		name    string
+		content string
+	}{
+		{"hyperfine/hyperfine", "binary content"},
+		{"hyperfine/README.md", "readme content"},
+		{"hyperfine/LICENSE", "license content"},
+	}
+
+	for _, file := range files {
+		header := &tar.Header{
+			Name: file.name,
+			Mode: 0o644,
+			Size: int64(len(file.content)),
+		}
+		err := tarWriter.WriteHeader(header)
+		require.NoError(t, err)
+
+		_, err = tarWriter.Write([]byte(file.content))
+		require.NoError(t, err)
+	}
+
+	err := tarWriter.Close()
+	require.NoError(t, err)
+	err = gzWriter.Close()
+	require.NoError(t, err)
+
+	// Test listing contents
+	result, err := ListTgzContents(&buf)
+	require.NoError(t, err)
+
+	expected := []string{"hyperfine/hyperfine", "hyperfine/README.md", "hyperfine/LICENSE"}
+	assert.Equal(t, expected, result)
+}
+
+func TestListZipContents(t *testing.T) {
+	// Create test zip content
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+
+	// Add test files
+	files := []struct {
+		name    string
+		content string
+	}{
+		{"hyperfine/hyperfine", "binary content"},
+		{"hyperfine/README.md", "readme content"},
+		{"hyperfine/LICENSE", "license content"},
+	}
+
+	for _, file := range files {
+		writer, err := zipWriter.Create(file.name)
+		require.NoError(t, err)
+
+		_, err = writer.Write([]byte(file.content))
+		require.NoError(t, err)
+	}
+
+	err := zipWriter.Close()
+	require.NoError(t, err)
+
+	// Test listing contents
+	result, err := ListZipContents(&buf)
+	require.NoError(t, err)
+
+	expected := []string{"hyperfine/hyperfine", "hyperfine/README.md", "hyperfine/LICENSE"}
+	assert.Equal(t, expected, result)
+}
+
+func TestListTarxzContents(t *testing.T) {
+	// Create test tar content first
+	var tarBuf bytes.Buffer
+	tarWriter := tar.NewWriter(&tarBuf)
+
+	// Add test files
+	files := []struct {
+		name    string
+		content string
+	}{
+		{"hyperfine/hyperfine", "binary content"},
+		{"hyperfine/README.md", "readme content"},
+	}
+
+	for _, file := range files {
+		header := &tar.Header{
+			Name: file.name,
+			Mode: 0o644,
+			Size: int64(len(file.content)),
+		}
+		err := tarWriter.WriteHeader(header)
+		require.NoError(t, err)
+
+		_, err = tarWriter.Write([]byte(file.content))
+		require.NoError(t, err)
+	}
+
+	err := tarWriter.Close()
+	require.NoError(t, err)
+
+	// Compress with xz
+	var xzBuf bytes.Buffer
+	xzWriter, err := xz.NewWriter(&xzBuf)
+	require.NoError(t, err)
+
+	_, err = xzWriter.Write(tarBuf.Bytes())
+	require.NoError(t, err)
+	err = xzWriter.Close()
+	require.NoError(t, err)
+
+	// Test listing contents
+	result, err := ListTarxzContents(&xzBuf)
+	require.NoError(t, err)
+
+	expected := []string{"hyperfine/hyperfine", "hyperfine/README.md"}
+	assert.Equal(t, expected, result)
+}
+
+func TestListArchiveContents(t *testing.T) {
+	tests := []struct {
+		name      string
+		assetName string
+		setupFunc func() *bytes.Buffer
+		expected  []string
 	}{
 		{
-			Name:           "Matches",
-			BinaryName:     "binary",
-			ExpectedResult: "foobar\n",
+			name:      "tar.gz file",
+			assetName: "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+			setupFunc: func() *bytes.Buffer {
+				var buf bytes.Buffer
+				gzWriter := gzip.NewWriter(&buf)
+				tarWriter := tar.NewWriter(gzWriter)
+
+				header := &tar.Header{
+					Name: "hyperfine",
+					Mode: 0o755,
+					Size: 100,
+				}
+				tarWriter.WriteHeader(header)
+				tarWriter.Write([]byte(strings.Repeat("x", 100)))
+				tarWriter.Close()
+				gzWriter.Close()
+				return &buf
+			},
+			expected: []string{"hyperfine"},
 		},
 		{
-			Name:        "Different",
-			BinaryName:  "other",
-			ExpectedErr: "no file named \"other\" found in archive",
+			name:      "zip file",
+			assetName: "hyperfine-v1.16.1-x86_64-pc-windows-msvc.zip",
+			setupFunc: func() *bytes.Buffer {
+				var buf bytes.Buffer
+				zipWriter := zip.NewWriter(&buf)
+				writer, _ := zipWriter.Create("hyperfine.exe")
+				writer.Write([]byte("binary"))
+				zipWriter.Close()
+				return &buf
+			},
+			expected: []string{"hyperfine.exe"},
 		},
-	} {
-		t.Run(testCase.Name, func(t *testing.T) {
-			file, err := os.Open("testdata/archives/binary.tgz")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer file.Close()
+		{
+			name:      "unsupported format",
+			assetName: "hyperfine.deb",
+			setupFunc: func() *bytes.Buffer {
+				return &bytes.Buffer{}
+			},
+			expected: nil,
+		},
+	}
 
-			result, err := unTgzFileNamed(testCase.BinaryName, file)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := tt.setupFunc()
+			result, err := ListArchiveContents(tt.assetName, buf)
 
-			if testCase.ExpectedResult != "" {
-				assert.Equal(t, []byte(testCase.ExpectedResult), result)
+			if tt.expected == nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported archive format")
 			} else {
-				assert.ErrorContains(t, err, testCase.ExpectedErr)
-			}
-		})
-	}
-}
-
-func TestUnTgzFileNamedInvalid(t *testing.T) {
-	file, err := os.Open("testdata/archives/binary")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = unTgzFileNamed("binary", file)
-
-	assert.ErrorContains(t, err, "error decompressing Gzipped data")
-}
-
-func TestUnZipFileNamedValid(t *testing.T) {
-	for _, testCase := range []struct {
-		Name           string
-		BinaryName     string
-		ExpectedErr    string
-		ExpectedResult string
-	}{
-		{
-			Name:           "Matches",
-			BinaryName:     "binary",
-			ExpectedResult: "foobar\n",
-		},
-		{
-			Name:        "Different",
-			BinaryName:  "other",
-			ExpectedErr: "no file named \"other\" found in archive",
-		},
-	} {
-		t.Run(testCase.Name, func(t *testing.T) {
-			file, err := os.Open("testdata/archives/binary.zip")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer file.Close()
-
-			result, err := unZipFileNamed(testCase.BinaryName, file)
-
-			if testCase.ExpectedResult != "" {
 				assert.NoError(t, err)
-				assert.Equal(t, []byte(testCase.ExpectedResult), result)
-			} else {
-				assert.ErrorContains(t, err, testCase.ExpectedErr)
+				assert.Equal(t, tt.expected, result)
 			}
 		})
 	}
-}
-
-func TestUnZipFileNamedInvalid(t *testing.T) {
-	file, err := os.Open("testdata/archives/binary")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = unZipFileNamed("binary", file)
-
-	assert.ErrorContains(t, err, "error decompressing Zipped data")
-}
-
-func TestUnGzipValid(t *testing.T) {
-	file, err := os.Open("testdata/archives/binary.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	result, err := unGzip(file)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, []byte("foobar\n"), result)
-}
-
-func TestUnGzipInvalid(t *testing.T) {
-	file, err := os.Open("testdata/archives/binary")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = unGzip(file)
-
-	assert.ErrorContains(t, err, "error decompressing Gzipped data")
-}
-
-func TestUnTarxzValid(t *testing.T) {
-	for _, testCase := range []struct {
-		Name           string
-		BinaryName     string
-		ExpectedErr    string
-		ExpectedResult string
-	}{
-		{
-			Name:           "Matches",
-			BinaryName:     "binary",
-			ExpectedResult: "foobar\n",
-		},
-		{
-			Name:        "Different",
-			BinaryName:  "other",
-			ExpectedErr: "no file named \"other\" found in archive",
-		},
-	} {
-		t.Run(testCase.Name, func(t *testing.T) {
-			file, err := os.Open("testdata/archives/binary.tar.xz")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer file.Close()
-
-			result, err := unTarxzFileNamed(testCase.BinaryName, file)
-
-			if testCase.ExpectedResult != "" {
-				assert.NoError(t, err)
-				assert.Equal(t, []byte(testCase.ExpectedResult), result)
-			} else {
-				assert.ErrorContains(t, err, testCase.ExpectedErr)
-			}
-		})
-	}
-}
-
-func TestUnTarxzInvalid(t *testing.T) {
-	file, err := os.Open("testdata/archives/binary")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = unTarxzFileNamed("binary", file)
-
-	assert.ErrorContains(t, err, "error decompressing xz data")
 }

--- a/pkg/archive_test.go
+++ b/pkg/archive_test.go
@@ -16,6 +16,7 @@ import (
 func TestListTgzContents(t *testing.T) {
 	// Create test tar.gz content
 	var buf bytes.Buffer
+
 	gzWriter := gzip.NewWriter(&buf)
 	tarWriter := tar.NewWriter(gzWriter)
 
@@ -58,6 +59,7 @@ func TestListTgzContents(t *testing.T) {
 func TestListZipContents(t *testing.T) {
 	// Create test zip content
 	var buf bytes.Buffer
+
 	zipWriter := zip.NewWriter(&buf)
 
 	// Add test files
@@ -92,6 +94,7 @@ func TestListZipContents(t *testing.T) {
 func TestListTarxzContents(t *testing.T) {
 	// Create test tar content first
 	var tarBuf bytes.Buffer
+
 	tarWriter := tar.NewWriter(&tarBuf)
 
 	// Add test files
@@ -121,6 +124,7 @@ func TestListTarxzContents(t *testing.T) {
 
 	// Compress with xz
 	var xzBuf bytes.Buffer
+
 	xzWriter, err := xz.NewWriter(&xzBuf)
 	require.NoError(t, err)
 
@@ -161,6 +165,7 @@ func TestListArchiveContents(t *testing.T) {
 				tarWriter.Write([]byte(strings.Repeat("x", 100)))
 				tarWriter.Close()
 				gzWriter.Close()
+
 				return &buf
 			},
 			expected: []string{"hyperfine"},
@@ -174,6 +179,7 @@ func TestListArchiveContents(t *testing.T) {
 				writer, _ := zipWriter.Create("hyperfine.exe")
 				writer.Write([]byte("binary"))
 				zipWriter.Close()
+
 				return &buf
 			},
 			expected: []string{"hyperfine.exe"},
@@ -188,17 +194,17 @@ func TestListArchiveContents(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			buf := tt.setupFunc()
-			result, err := ListArchiveContents(tt.assetName, buf)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			buf := testCase.setupFunc()
+			result, err := ListArchiveContents(testCase.assetName, buf)
 
-			if tt.expected == nil {
+			if testCase.expected == nil {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "unsupported archive format")
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+				assert.Equal(t, testCase.expected, result)
 			}
 		})
 	}

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -161,7 +161,7 @@ func detectPackage(ghClient github.Client, org, repo string, release *github.Rel
 	}
 
 	// Detect embedded binary paths for archive assets
-	embeddedPaths, err := detectEmbeddedBinaryPaths(ghClient, org, repo, release, packageName, fileNames)
+	embeddedPaths, err := detectEmbeddedBinaryPaths(ghClient, org, repo, release, packageName, fileNames, latestVersion)
 	if err != nil {
 		slog.WarnContext(context.Background(), "Failed to detect embedded binary paths", "error", err)
 		// Continue without embedded paths rather than failing completely
@@ -195,6 +195,7 @@ func detectEmbeddedBinaryPaths(
 	release *github.Release,
 	packageName string,
 	detectedAssets map[string]string,
+	versionLiteral string,
 ) (*map[string]string, error) {
 	ctx := context.Background()
 	slog.InfoContext(ctx, "Detecting embedded binary paths", "package", packageName)
@@ -232,7 +233,9 @@ func detectEmbeddedBinaryPaths(
 			continue
 		}
 
-		embeddedPaths[platformArch] = binaryPath
+		// Template the binary path by replacing version literals
+		templatedPath := UnrenderVersionValue(binaryPath, versionLiteral)
+		embeddedPaths[platformArch] = templatedPath
 		slog.InfoContext(ctx, "Detected embedded binary path", "platformArch", platformArch, "path", binaryPath)
 	}
 

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -162,7 +162,7 @@ func TestDetectEmbeddedBinaryPaths(t *testing.T) {
 	}
 
 	detectedAssets := map[string]string{
-		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+		"linux,amd64": "hyperfine-v{{ .Version }}-x86_64-unknown-linux-gnu.tar.gz",
 	}
 
 	// Create tar.gz with binary in subdirectory (not at root, so it needs embedded path)
@@ -197,7 +197,7 @@ func TestDetectEmbeddedBinaryPathsWithSubdirectory(t *testing.T) {
 	}
 
 	detectedAssets := map[string]string{
-		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+		"linux,amd64": "hyperfine-v{{ .Version }}-x86_64-unknown-linux-gnu.tar.gz",
 	}
 
 	// Create tar.gz with binary in subdirectory (like real hyperfine releases)
@@ -233,7 +233,7 @@ func TestDetectEmbeddedBinaryPathsSkipsNonArchives(t *testing.T) {
 	}
 
 	detectedAssets := map[string]string{
-		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu", // Not an archive
+		"linux,amd64": "hyperfine-v{{ .Version }}-x86_64-unknown-linux-gnu", // Not an archive
 	}
 
 	mockClient := &MockGitHubClient{
@@ -256,7 +256,7 @@ func TestDetectEmbeddedBinaryPathsHandlesDownloadFailure(t *testing.T) {
 	}
 
 	detectedAssets := map[string]string{
-		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+		"linux,amd64": "hyperfine-v{{ .Version }}-x86_64-unknown-linux-gnu.tar.gz",
 	}
 
 	mockClient := &MockGitHubClient{
@@ -282,8 +282,8 @@ func TestDetectEmbeddedBinaryPathsVersionTemplating(t *testing.T) {
 	}
 
 	detectedAssets := map[string]string{
-		"darwin,amd64": "tool-v2.5.0-darwin-amd64.tar.gz",
-		"linux,arm64":  "tool-v2.5.0-linux-arm64.tar.gz",
+		"darwin,amd64": "tool-v{{ .Version }}-darwin-amd64.tar.gz",
+		"linux,arm64":  "tool-v{{ .Version }}-linux-arm64.tar.gz",
 	}
 
 	// Create archives with version in binary path

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -1,138 +1,286 @@
 package importer
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bytes"
-	"os"
-	"path/filepath"
+	"compress/gzip"
+	"errors"
 	"testing"
 
-	"github.com/noizwaves/grab/pkg"
-	"github.com/noizwaves/grab/pkg/github"
-	"github.com/noizwaves/grab/pkg/internal/githubh"
-	"github.com/noizwaves/grab/pkg/internal/osh"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/noizwaves/grab/pkg/github"
 )
 
-// Happy path test.
-func TestImport_Success(t *testing.T) {
-	configDir := osh.CopyDir(t, "../testdata/contexts/simple")
+// Mock GitHub client for testing.
+type MockGitHubClient struct {
+	downloadResponses map[string][]byte
+	downloadErrors    map[string]error
+}
 
-	gCtx, err := pkg.NewGrabContext(configDir, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
+func (m *MockGitHubClient) GetLatestRelease(org, repo string) (*github.Release, error) {
+	return nil, errors.New("not implemented for test")
+}
+
+func (m *MockGitHubClient) GetReleaseByTag(org, repo, tag string) (*github.Release, error) {
+	return nil, errors.New("not implemented for test")
+}
+
+func (m *MockGitHubClient) DownloadReleaseAsset(org, repo, release, asset string) ([]byte, error) {
+	if err, exists := m.downloadErrors[asset]; exists {
+		return nil, err
+	}
+	if data, exists := m.downloadResponses[asset]; exists {
+		return data, nil
+	}
+	return nil, errors.New("asset not found in mock")
+}
+
+func TestIsArchiveAsset(t *testing.T) {
+	tests := []struct {
+		assetName string
+		expected  bool
+	}{
+		{"hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz", true},
+		{"hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tgz", true},
+		{"hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.xz", true},
+		{"hyperfine-v1.16.1-x86_64-pc-windows-msvc.zip", true},
+		{"hyperfine-v1.16.1-x86_64-unknown-linux-gnu", false},
+		{"hyperfine_1.16.1_amd64.deb", false},
+		{"hyperfine-1.16.1-1.x86_64.rpm", false},
 	}
 
-	mockRelease := &github.Release{
-		TagName: "v1.2.3",
-		Assets: []github.Asset{
-			{Name: "myapp-1.2.3-linux-amd64.tar.gz"},
-			{Name: "myapp-1.2.3-linux-arm64.tar.gz"},
-			{Name: "myapp-1.2.3-darwin-amd64.tar.gz"},
-			{Name: "myapp-1.2.3-darwin-arm64.tar.gz"},
+	for _, tt := range tests {
+		t.Run(tt.assetName, func(t *testing.T) {
+			result := isArchiveAsset(tt.assetName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindBinaryInArchive(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       []string
+		packageName string
+		expected    string
+	}{
+		{
+			name:        "exact match at root",
+			files:       []string{"hyperfine", "README.md", "LICENSE"},
+			packageName: "hyperfine",
+			expected:    "hyperfine",
+		},
+		{
+			name:        "exact match in subdirectory",
+			files:       []string{"hyperfine/hyperfine", "hyperfine/README.md", "hyperfine/LICENSE"},
+			packageName: "hyperfine",
+			expected:    "hyperfine/hyperfine",
+		},
+		{
+			name:        "exact match with extension on Windows",
+			files:       []string{"hyperfine.exe", "README.md"},
+			packageName: "hyperfine.exe",
+			expected:    "hyperfine.exe",
+		},
+		{
+			name:        "partial match fallback",
+			files:       []string{"hyperfine-bin", "README.md"},
+			packageName: "hyperfine",
+			expected:    "hyperfine-bin",
+		},
+		{
+			name:        "no match",
+			files:       []string{"other-binary", "README.md"},
+			packageName: "hyperfine",
+			expected:    "",
+		},
+		{
+			name:        "skip directories",
+			files:       []string{"hyperfine/", "hyperfine/hyperfine", "README.md"},
+			packageName: "hyperfine",
+			expected:    "hyperfine/hyperfine",
+		},
+		{
+			name:        "prefer exact over partial match",
+			files:       []string{"hyperfine-extended", "hyperfine", "README.md"},
+			packageName: "hyperfine",
+			expected:    "hyperfine",
 		},
 	}
 
-	importer := NewImporter(&githubh.MockGitHubClient{
-		Release: mockRelease,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findBinaryInArchive(tt.files, tt.packageName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func createTestTarGz(files map[string]string) []byte {
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	for name, content := range files {
+		header := &tar.Header{
+			Name: name,
+			Mode: 0o755,
+			Size: int64(len(content)),
+		}
+		tarWriter.WriteHeader(header)
+		tarWriter.Write([]byte(content))
+	}
+
+	tarWriter.Close()
+	gzWriter.Close()
+	return buf.Bytes()
+}
+
+func createTestZip(files map[string]string) []byte {
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+
+	for name, content := range files {
+		writer, _ := zipWriter.Create(name)
+		writer.Write([]byte(content))
+	}
+
+	zipWriter.Close()
+	return buf.Bytes()
+}
+
+func TestDetectEmbeddedBinaryPaths(t *testing.T) {
+	release := &github.Release{
+		TagName: "v1.16.1",
+	}
+
+	detectedAssets := map[string]string{
+		"linux,amd64":  "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+		"darwin,amd64": "hyperfine-v1.16.1-x86_64-apple-darwin.tar.gz",
+		"linux,arm64":  "hyperfine-v1.16.1-aarch64-unknown-linux-gnu.tar.gz",
+	}
+
+	// Setup mock responses
+	linuxTarGz := createTestTarGz(map[string]string{
+		"hyperfine": "linux binary content",
+	})
+	darwinTarGz := createTestTarGz(map[string]string{
+		"hyperfine": "darwin binary content",
+	})
+	arm64TarGz := createTestTarGz(map[string]string{
+		"hyperfine": "arm64 binary content",
 	})
 
-	out := bytes.Buffer{}
-	err = importer.Import(gCtx, "https://github.com/foo/myapp", &out)
-
-	assert.NoError(t, err)
-	assert.Contains(t, out.String(), `Package "myapp" saved to`)
-	assert.Contains(t, out.String(), `/myapp.yml`)
-
-	// Verify the contents of the package YAML file
-	expectedYamlPath := filepath.Join(configDir, "repository", "myapp.yml")
-	actualYaml, err := os.ReadFile(expectedYamlPath)
-	assert.NoError(t, err)
-
-	expectedYaml := `apiVersion: grab.noizwaves.com/v1alpha1
-kind: Package
-metadata:
-  name: myapp
-spec:
-  gitHubRelease:
-    org: foo
-    repo: myapp
-    name: v{{ .Version }}
-    versionRegex: \d+\.\d+\.\d+
-    fileName:
-      darwin,amd64: myapp-{{ .Version }}-darwin-amd64.tar.gz
-      darwin,arm64: myapp-{{ .Version }}-darwin-arm64.tar.gz
-      linux,amd64: myapp-{{ .Version }}-linux-amd64.tar.gz
-      linux,arm64: myapp-{{ .Version }}-linux-arm64.tar.gz
-  program:
-    versionArgs: [--version]
-    versionRegex: \d+\.\d+\.\d+
-`
-
-	assert.Equal(t, expectedYaml, string(actualYaml))
-}
-
-// TestImport_Error_InvalidURL tests error handling for invalid URLs.
-func TestImport_Error_InvalidURL(t *testing.T) {
-	configDir := osh.CopyDir(t, "../testdata/contexts/simple")
-
-	gCtx, err := pkg.NewGrabContext(configDir, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
+	mockClient := &MockGitHubClient{
+		downloadResponses: map[string][]byte{
+			"hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz":  linuxTarGz,
+			"hyperfine-v1.16.1-x86_64-apple-darwin.tar.gz":       darwinTarGz,
+			"hyperfine-v1.16.1-aarch64-unknown-linux-gnu.tar.gz": arm64TarGz,
+		},
+		downloadErrors: map[string]error{},
 	}
 
-	importer := NewImporter(&githubh.MockGitHubClient{})
+	result, err := detectEmbeddedBinaryPaths(mockClient, "sharkdp", "hyperfine", release, "hyperfine", detectedAssets)
+	require.NoError(t, err)
 
-	out := bytes.Buffer{}
-	err = importer.Import(gCtx, "https://example.com/invalid/url", &out)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid")
-}
-
-// TestImport_Error_GitHubAPIFailure tests error handling when GitHub API fails.
-func TestImport_Error_GitHubAPIFailure(t *testing.T) {
-	configDir := osh.CopyDir(t, "../testdata/contexts/simple")
-
-	gCtx, err := pkg.NewGrabContext(configDir, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
+	expected := map[string]string{
+		"linux,amd64":  "hyperfine",
+		"darwin,amd64": "hyperfine",
+		"linux,arm64":  "hyperfine",
 	}
 
-	// MockGitHubClient with no Release set will return "not implemented" error
-	importer := NewImporter(&githubh.MockGitHubClient{})
-
-	out := bytes.Buffer{}
-	err = importer.Import(gCtx, "https://github.com/foo/myapp/releases/latest", &out)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get release")
+	assert.Equal(t, expected, result)
 }
 
-// TestImport_Error_NoMatchingAssets tests error handling when no assets match platform/arch.
-func TestImport_Error_NoMatchingAssets(t *testing.T) {
-	configDir := osh.CopyDir(t, "../testdata/contexts/simple")
-
-	gCtx, err := pkg.NewGrabContext(configDir, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
+func TestDetectEmbeddedBinaryPathsWithSubdirectory(t *testing.T) {
+	release := &github.Release{
+		TagName: "v1.16.1",
 	}
 
-	// Release with assets that don't match any platform/arch patterns
-	mockRelease := &github.Release{
-		TagName: "v1.2.3",
-		Assets: []github.Asset{
-			{Name: "myapp-1.2.3-unknown-platform.tar.gz"},
-			{Name: "myapp-1.2.3-windows-x72.zip"},
+	detectedAssets := map[string]string{
+		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+	}
+
+	// Create tar.gz with binary in subdirectory (like real hyperfine releases)
+	linuxTarGz := createTestTarGz(map[string]string{
+		"hyperfine-v1.16.1-x86_64-unknown-linux-gnu/hyperfine": "binary content",
+		"hyperfine-v1.16.1-x86_64-unknown-linux-gnu/README.md": "readme",
+		"hyperfine-v1.16.1-x86_64-unknown-linux-gnu/LICENSE":   "license",
+	})
+
+	mockClient := &MockGitHubClient{
+		downloadResponses: map[string][]byte{
+			"hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz": linuxTarGz,
+		},
+		downloadErrors: map[string]error{},
+	}
+
+	result, err := detectEmbeddedBinaryPaths(mockClient, "sharkdp", "hyperfine", release, "hyperfine", detectedAssets)
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu/hyperfine",
+	}
+
+	assert.Equal(t, expected, result)
+}
+
+func TestDetectEmbeddedBinaryPathsSkipsNonArchives(t *testing.T) {
+	release := &github.Release{
+		TagName: "v1.16.1",
+	}
+
+	detectedAssets := map[string]string{
+		"linux,amd64": "hyperfine-v1.16.1-x86_64-unknown-linux-gnu", // Not an archive
+	}
+
+	mockClient := &MockGitHubClient{
+		downloadResponses: map[string][]byte{},
+		downloadErrors:    map[string]error{},
+	}
+
+	result, err := detectEmbeddedBinaryPaths(mockClient, "sharkdp", "hyperfine", release, "hyperfine", detectedAssets)
+	require.NoError(t, err)
+
+	// Should return empty map since non-archive assets are skipped
+	expected := map[string]string{}
+	assert.Equal(t, expected, result)
+}
+
+func TestDetectEmbeddedBinaryPathsHandlesDownloadFailure(t *testing.T) {
+	release := &github.Release{
+		TagName: "v1.16.1",
+	}
+
+	detectedAssets := map[string]string{
+		"linux,amd64":  "hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz",
+		"darwin,amd64": "hyperfine-v1.16.1-x86_64-apple-darwin.tar.gz",
+	}
+
+	// Setup mock responses - one succeeds, one fails
+	linuxTarGz := createTestTarGz(map[string]string{
+		"hyperfine": "binary content",
+	})
+
+	mockClient := &MockGitHubClient{
+		downloadResponses: map[string][]byte{
+			"hyperfine-v1.16.1-x86_64-unknown-linux-gnu.tar.gz": linuxTarGz,
+		},
+		downloadErrors: map[string]error{
+			"hyperfine-v1.16.1-x86_64-apple-darwin.tar.gz": errors.New("download failed"),
 		},
 	}
 
-	importer := NewImporter(&githubh.MockGitHubClient{
-		Release: mockRelease,
-	})
+	result, err := detectEmbeddedBinaryPaths(mockClient, "sharkdp", "hyperfine", release, "hyperfine", detectedAssets)
+	require.NoError(t, err)
 
-	out := bytes.Buffer{}
-	err = importer.Import(gCtx, "https://github.com/foo/myapp/releases/latest", &out)
+	// Should only include the successful one
+	expected := map[string]string{
+		"linux,amd64": "hyperfine",
+	}
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no matching asset name found")
+	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
Now `grab import` will create package definitions with correct embedded binary paths:

```
❯ ./grab --config-path testdata/simple/.grab import https://github.com/sharkdp/hyperfine
Package "hyperfine" saved to testdata/simple/.grab/repository/hyperfine.yml

❯ cat testdata/simple/.grab/repository/hyperfine.yml
apiVersion: grab.noizwaves.com/v1alpha1
kind: Package
metadata:
  name: hyperfine
spec:
  gitHubRelease:
    org: sharkdp
    repo: hyperfine
    name: v{{ .Version }}
    versionRegex: \d+\.\d+\.\d+
    fileName:
      darwin,amd64: hyperfine-v{{ .Version }}-x86_64-apple-darwin.tar.gz
      darwin,arm64: hyperfine-v{{ .Version }}-aarch64-apple-darwin.tar.gz
      linux,amd64: hyperfine-v{{ .Version }}-x86_64-unknown-linux-gnu.tar.gz
      linux,arm64: hyperfine-v{{ .Version }}-aarch64-unknown-linux-gnu.tar.gz
    embeddedBinaryPath:
      darwin,amd64: hyperfine-v{{ .Version }}-x86_64-apple-darwin/hyperfine
      darwin,arm64: hyperfine-v{{ .Version }}-aarch64-apple-darwin/hyperfine
      linux,amd64: hyperfine-v{{ .Version }}-x86_64-unknown-linux-gnu/hyperfine
      linux,arm64: hyperfine-v{{ .Version }}-aarch64-unknown-linux-gnu/hyperfine
  program:
    versionArgs: [--version]
    versionRegex: \d+\.\d+\.\d+
```